### PR TITLE
SCPMA-560: Async method

### DIFF
--- a/common/common-compare-with-patterns.js
+++ b/common/common-compare-with-patterns.js
@@ -25,7 +25,7 @@ export function getAndMatchArrayWithOptions(url, elementPattern,
         allowEmpty = false
     } = {}) {
     const request = { method: 'GET', url: url, auth: auth, failOnStatusCode: failOnStatusCode }
-    callAndMatchArray(request, elementPattern, headerPattern, subpath, allowEmpty)
+    return callAndMatchArray(request, elementPattern, headerPattern, subpath, allowEmpty)
 }
 
  export function postAndMatchWithOptions(url, postBody, pattern, 


### PR DESCRIPTION
Enable **.then()** chaining.

No negative effects, existing tests that don't use **.then()** after these functions will continue to work as before. The return value is simply ignored if not used.