### PR TITLE
SCPMA-850: fix(header-pattern): Accept 1-2 cookies during gcp-logging upgrade

### DIFF
--- a/fixtures/common-header-pattern.js
+++ b/fixtures/common-header-pattern.js
@@ -8,9 +8,14 @@ export const commonHeaderPattern = {
     "date": (date) => _.isOmitted(date) || _.isDateString(date),
     "expires": _.isString,
     "pragma": "no-cache",
-    "set-cookie": [(cStr) => {
-        return cStr.includes("Path=/; Secure; HttpOnly") && cStr.includes("correlationId=")
-    }],
+    "set-cookie": (cookies) => {
+        // Accept 1 or 2 cookies during gcp-logging upgrade rollout (SCPMA-578/SCPMA-580)
+        if (!Array.isArray(cookies)) return false;
+        if (cookies.length < 1 || cookies.length > 2) return false;
+        return cookies.every(cStr =>
+            cStr.includes("Path=/; Secure; HttpOnly") && cStr.includes("correlationId=")
+        );
+    },
     "strict-transport-security": "max-age=31536000 ; includeSubDomains",
     "vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
     "x-content-type-options": "nosniff",

--- a/fixtures/common-header-pattern.js
+++ b/fixtures/common-header-pattern.js
@@ -10,11 +10,11 @@ export const commonHeaderPattern = {
     "pragma": "no-cache",
     "set-cookie": (cookies) => {
         // Accept 1 or 2 cookies during gcp-logging upgrade rollout (SCPMA-578/SCPMA-580)
-        if (!Array.isArray(cookies)) return false;
-        if (cookies.length < 1 || cookies.length > 2) return false;
-        return cookies.every(cStr =>
-            cStr.includes("Path=/; Secure; HttpOnly") && cStr.includes("correlationId=")
-        );
+        return Array.isArray(cookies) &&
+            (cookies.length === 1 || cookies.length === 2) &&
+            cookies.every(cStr =>
+                cStr.includes("Path=/; Secure; HttpOnly") && cStr.includes("correlationId=")
+            );
     },
     "strict-transport-security": "max-age=31536000 ; includeSubDomains",
     "vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",


### PR DESCRIPTION
During the gradual rollout of SCPMA-580 (gcp-logging upgrade to fix duplicate Set-Cookie headers), services return either 1 or 2 cookies.

This change allows the commonHeaderPattern to accept both cases, preventing test failures while the upgrade is being deployed.

Related: SCPMA-578, SCPMA-580